### PR TITLE
Correctly parse ISBNs with space

### DIFF
--- a/mwcites/extractors/isbn.py
+++ b/mwcites/extractors/isbn.py
@@ -1,8 +1,13 @@
 import re
 from ..identifier import Identifier
 
-ISBN_RE = re.compile('isbn\s?=?\s?([0-9\-Xx]+)', re.I)
+# Also correctly parses malformed inputs such as below:
+# isbn=2 906700-09-6 (malformed input — notice the space)
+ISBN_RE = re.compile('isbn\s?=?\s?(([0-9]+\s)?([0-9\-Xx]+))', re.I)
 
 def extract(text):
     for match in ISBN_RE.finditer(text):
-        yield Identifier('isbn', match.group(1).replace('-', ''))
+        yield Identifier(
+            'isbn',
+            match.group(1).replace('-', '').replace(' ', '')
+        )

--- a/mwcites/extractors/tests/test_isbn.py
+++ b/mwcites/extractors/tests/test_isbn.py
@@ -5,6 +5,7 @@ from .. import isbn
 from ...identifier import Identifier
 
 INPUT_TEXT = """
+    | isbn=2 906700-09-6
     | publisher=Academic Press | isbn=0124366031
     | isbn=3540206310
     | accessdate=2008-02-05 | isbn=0-618-34342-3
@@ -22,6 +23,7 @@ INPUT_TEXT = """
 
 
 EXPECTED = [
+    Identifier('isbn', '2906700096'),
     Identifier('isbn', '0124366031'),
     Identifier('isbn', '3540206310'),
     Identifier('isbn', '0618343423'),


### PR DESCRIPTION
Sometimes, e.g. [1], ISBN numbers are typed erroneously as
"isbn=2 906700-09-6" (notice the space after 2). This patch recognizes
such ISBNs as valid.

[1] https://fr.wikipedia.org/w/index.php?diff=prev&oldid=83778617