### PR TITLE
Recognize ISBNs with spaces as valid numbers

### DIFF
--- a/mwcites/extractors/isbn.py
+++ b/mwcites/extractors/isbn.py
@@ -2,12 +2,14 @@ import re
 from ..identifier import Identifier
 
 # Also correctly parses malformed inputs such as below:
-# isbn=2 906700-09-6 (malformed input — notice the space)
-ISBN_RE = re.compile('isbn\s?=?\s?(([0-9]+\s)?([0-9\-Xx]+))', re.I)
+# isbn=2 906700-09-6 (notice the space instead of a hyphen) or
+# isbn=2 10 004179 7 (notice spaces instead of hyphens)
+ISBN_RE = re.compile('isbn\s?=?\s?([\d]+([\d\s\-]+)[\dXx])', re.I)
+
 
 def extract(text):
     for match in ISBN_RE.finditer(text):
         yield Identifier(
             'isbn',
-            match.group(1).replace('-', '').replace(' ', '')
+            match.group(1).replace('-', '').replace(' ', '').strip()
         )

--- a/mwcites/extractors/tests/test_isbn.py
+++ b/mwcites/extractors/tests/test_isbn.py
@@ -6,6 +6,7 @@ from ...identifier import Identifier
 
 INPUT_TEXT = """
     | isbn=2 906700-09-6
+    | isbn=2 10 004179 7
     | publisher=Academic Press | isbn=0124366031
     | isbn=3540206310
     | accessdate=2008-02-05 | isbn=0-618-34342-3
@@ -24,6 +25,7 @@ INPUT_TEXT = """
 
 EXPECTED = [
     Identifier('isbn', '2906700096'),
+    Identifier('isbn', '2100041797'),
     Identifier('isbn', '0124366031'),
     Identifier('isbn', '3540206310'),
     Identifier('isbn', '0618343423'),


### PR DESCRIPTION
Some pages, e.g. [1], contain ISBNs with spaces, e.g.  2 10 004179 7.
The patch identifies these ISBNs as valid numbers.

[1] https://fr.wikipedia.org/wiki/Mahmoud_Sami-Ali?oldid=145625233