### PR TITLE
ISBN regexp improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ docs/_build/
 
 # Pycharm directories
 .idea
+venv/

--- a/mwcites/extractors/isbn.py
+++ b/mwcites/extractors/isbn.py
@@ -4,7 +4,8 @@ from ..identifier import Identifier
 # Also correctly parses malformed inputs such as below:
 # isbn=2 906700-09-6 (notice the space instead of a hyphen) or
 # isbn=2 10 004179 7 (notice spaces instead of hyphens)
-ISBN_RE = re.compile('isbn\s?=?\s?([\d]+([\d\s\-]+)[\dXx])', re.I)
+# {{ISBN|978-83-7435-239-0​}} (notice pipe instead of equals)
+ISBN_RE = re.compile('isbn\s?[=|\|]?\s?([\d]+([\d\s\-]+)[\dXx])', re.I)
 
 
 def extract(text):

--- a/mwcites/extractors/isbn.py
+++ b/mwcites/extractors/isbn.py
@@ -5,7 +5,7 @@ from ..identifier import Identifier
 # isbn=2 906700-09-6 (notice the space instead of a hyphen) or
 # isbn=2 10 004179 7 (notice spaces instead of hyphens)
 # {{ISBN|978-83-7435-239-0​}} (notice pipe instead of equals)
-ISBN_RE = re.compile('isbn\s?[=|\|]?\s?([\d]+([\d\s\-]+)[\dXx])', re.I)
+ISBN_RE = re.compile('isbn\s?[=|]?\s?([\d]+([\d\s\-]+)[\dXx])', re.I)
 
 
 def extract(text):

--- a/mwcites/extractors/tests/test_isbn.py
+++ b/mwcites/extractors/tests/test_isbn.py
@@ -20,6 +20,9 @@ INPUT_TEXT = """
     &lt;ref name=&quot;flos1&quot;&gt;{{Literatur | Autor = René Flosdorff, Günther Hilgarth | Titel = Elektrische Energieverteilung | Verlag = Teubner | Auflage = 8. | Jahr = 2003 | Kapitel = Kapitel 1.2.2.4 | ISBN = 3-519-26424-2 }}&lt;/ref&gt;
     Bei einer [[Sprungtemperatur]] von 1,2&amp;nbsp;K wird reines Aluminium [[Supraleiter|supraleitend]].&lt;ref&gt;{{Literatur | Autor = Ilschner | first = Bernhard | Titel = Werkstoffwissenschaften und Fertigungstechnik Eigenschaften, Vorgänge, Technologien | Verlag = Springer | Ort = Berlin | Jahr = 2010 | ISBN = 978-3-642-01734-6 | Seiten = 277}}&lt;/ref&gt;
     * {{Literatur | Autor=Michael J. Padilla, Ioannis Miaoulis, Martha Cyr | Jahr = 2002 | Titel = Prentice Hall Science Explorer: Chemical Building Blocks | Verlag = Prentice-Hall, Inc. | Ort = Upper Saddle River, New Jersey USA | ISBN = 0-13-054091-9 | |Originalsprache=en}}
+    * ISBN 0 902 198 84 X
+    * ISBN 1-57488-530-8
+    * {{ISBN|978-83-7435-239-0​}}
     """
 
 
@@ -39,6 +42,9 @@ EXPECTED = [
     Identifier('isbn', '3519264242'),
     Identifier('isbn', '9783642017346'),
     Identifier('isbn', '0130540919'),
+    Identifier('isbn', '090219884X'),
+    Identifier('isbn', '1574885308'),
+    Identifier('isbn', '9788374352390'),
 ]
 
 def test_extract():

--- a/mwcites/utilities/extract.py
+++ b/mwcites/utilities/extract.py
@@ -60,11 +60,11 @@ def main(argv=None):
     run(dump_files, extractors)
 
 def run(dump_files, extractors):
-    writer = mysqltsv.Writer(sts.stdout, headers=HEADERS)
+    writer = mysqltsv.Writer(sys.stdout, headers=HEADERS)
 
     cites = extract(dump_files, extractors=extractors)
     for page_id, title, rev_id, timestamp, type, id in cites:
-        writer.write(page_id, title, rev_id, timestamp.long_format(), type, id)
+        writer.write([page_id, title, rev_id, timestamp.long_format(), type, id])
 
 def extract(dump_files, extractors=ALL_EXTRACTORS):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ docopt
 more-itertools
 mwparserfromhell
 mwxml
+mysqltsv


### PR DESCRIPTION
An ISBN regexp improvement allowing to extract more polluted citations like `902 198 84 X`, `1-57488-530-8`, and `{{ISBN|978-83-7435-239-0​}}` ones.

In colleague's work - he reported to extract **30-40%** percentage more **valid** citations after the fix.

(Also contains minor code cleanup and fixes)